### PR TITLE
Update Regexes involving lowercase letters

### DIFF
--- a/schema/strict/module.json
+++ b/schema/strict/module.json
@@ -214,7 +214,7 @@
                      ],
                      "title": "Package Name",
                      "type": "string",
-                     "pattern": "^([a-z0-9]+-?)*[a-z0-9]+$",
+                     "pattern": "^([\\p{Lowercase Letters}0-9]+-?)*[\\p{Lowercase Letters}0-9]+$",
                      "errorMessage": {
                         "pattern": "should be a string that is lowercase alpha-numeric with only separating hyphens"
                      }
@@ -350,12 +350,12 @@
                         "oneOf": [
                            {
                               "type": "string",
-                              "pattern": "^([a-zA-Z0-9]+[-_]?)*[a-zA-Z0-9]+$"
+                              "pattern": "^([\\p{Lowercase Letters}0-9]+-?)*[\\p{Lowercase Letters}0-9]+$"
                            },
                            {
                               "items": {
                                  "type": "string",
-                                 "pattern": "^([a-zA-Z0-9]+[-_]?)*[a-zA-Z0-9]+$"
+                                 "pattern": "^([\\p{Lowercase Letters}0-9]+-?)*[\\p{Lowercase Letters}0-9]+$"
                               },
                               "type": "array"
                            }
@@ -401,7 +401,7 @@
                         ],
                         "title": "Pack Module",
                         "type": "string",
-                        "pattern": "^([a-z0-9]+-?)*[a-z0-9]+$",
+                        "pattern": "^([\\p{Lowercase Letters}0-9]+-?)*[\\p{Lowercase Letters}0-9]+$",
                         "errorMessage": {
                            "pattern": "should be a string that is lowercase alpha-numeric with only separating hyphens"
                         }
@@ -413,7 +413,7 @@
                         ],
                         "title": "Pack Name",
                         "type": "string",
-                        "pattern": "^([a-z0-9]+-?)*[a-z0-9]+$",
+                        "pattern": "^([\\p{Lowercase Letters}0-9]+-?)*[\\p{Lowercase Letters}0-9]+$",
                         "errorMessage": {
                            "pattern": "should be a string that is lowercase alpha-numeric with only separating hyphens"
                         }
@@ -447,12 +447,12 @@
                "oneOf": [
                   {
                      "type": "string",
-                     "pattern": "^([a-zA-Z0-9]+[-_]?)*[a-zA-Z0-9]+$"
+                     "pattern": "^([\\p{Lowercase Letters}0-9]+-?)*[\\p{Lowercase Letters}0-9]+$"
                   },
                   {
                      "items": {
                         "type": "string",
-                        "pattern": "^([a-zA-Z0-9]+[-_]?)*[a-zA-Z0-9]+$"
+                        "pattern": "^([\\p{Lowercase Letters}0-9]+-?)*[\\p{Lowercase Letters}0-9]+$"
                      },
                      "type": "array"
                   }

--- a/schema/strict/system.json
+++ b/schema/strict/system.json
@@ -214,7 +214,7 @@
                      ],
                      "title": "Package Name",
                      "type": "string",
-                     "pattern": "^([a-z0-9]+-?)*[a-z0-9]+$",
+                     "pattern": "^([\\p{Lowercase Letters}0-9]+-?)*[\\p{Lowercase Letters}0-9]+$",
                      "errorMessage": {
                         "pattern": "should be a string that is lowercase alpha-numeric with only separating hyphens"
                      }
@@ -373,7 +373,7 @@
                         ],
                         "title": "Pack System",
                         "type": "string",
-                        "pattern": "^([a-z0-9]+-?)*[a-z0-9]+$",
+                        "pattern": "^([\\p{Lowercase Letters}0-9]+-?)*[\\p{Lowercase Letters}0-9]+$",
                         "errorMessage": {
                            "pattern": "should be a string that is lowercase alpha-numeric with only separating hyphens"
                         }
@@ -416,7 +416,7 @@
                         ],
                         "title": "Pack Module",
                         "type": "string",
-                        "pattern": "^([a-z0-9]+-?)*[a-z0-9]+$",
+                        "pattern": "^([\\p{Lowercase Letters}0-9]+-?)*[\\p{Lowercase Letters}0-9]+$",
                         "errorMessage": {
                            "pattern": "should be a string that is lowercase alpha-numeric with only separating hyphens"
                         }
@@ -428,7 +428,7 @@
                         ],
                         "title": "Pack Name",
                         "type": "string",
-                        "pattern": "^([a-z0-9]+-?)*[a-z0-9]+$",
+                        "pattern": "^([\\p{Lowercase Letters}0-9]+-?)*[\\p{Lowercase Letters}0-9]+$",
                         "errorMessage": {
                            "pattern": "should be a string that is lowercase alpha-numeric with only separating hyphens"
                         }


### PR DESCRIPTION
There's the possibility that this is purposeful because Foundry in some way limits "lowercase letters" to just `a-z` but if not, I believe `\\p{Lowercase Letters}` is an appropriate replacement here.